### PR TITLE
implement as_raw_fd for TimeoutReader and TimeoutWriter

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -41,6 +41,14 @@ impl<H> Read for TimeoutReader<H>
     }
 }
 
+impl<H> AsRawFd for TimeoutReader<H>
+    where H: Read + AsRawFd
+{
+    fn as_raw_fd(&self) -> c_int {
+        self.handle.as_raw_fd()
+    }
+}
+
 impl<H> Clone for TimeoutReader<H>
     where H: Read + AsRawFd + Clone
 {
@@ -135,12 +143,15 @@ mod tests {
         regular_file.push("regular_file.txt");
 
         let fp = File::open(regular_file).unwrap();
+        let fp_fd = fp.as_raw_fd();
         let mut fp = TimeoutReader::new(fp, Duration::new(5, 0));
 
         let mut read_contents = String::new();
         fp.read_to_string(&mut read_contents).unwrap();
 
         assert_eq!(original_contents, read_contents);
+
+        assert_eq!(fp_fd, fp.as_raw_fd());
     }
 
     #[test]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -46,6 +46,14 @@ impl<H> Write for TimeoutWriter<H>
     }
 }
 
+impl<H> AsRawFd for TimeoutWriter<H>
+    where H: Write + AsRawFd
+{
+    fn as_raw_fd(&self) -> c_int {
+        self.handle.as_raw_fd()
+    }
+}
+
 impl<H> Clone for TimeoutWriter<H>
     where H: Write + AsRawFd + Clone
 {


### PR DESCRIPTION
This simplifies my code a bit. Otherwise I have to get the fd before wrapping into the TimeoutReader/Writer.