### PR TITLE
Bump nix dependency to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.2.1-alpha.0"
 repository = "jcreekmore/timeout-readwrite-rs"
 
 [dependencies]
-nix = "0.13.0"
+nix = "0.14.0"
 
 [dev-dependencies]
 lazy_static = "1.3.0"

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use nix::libc::c_int;
-use nix::poll::EventFlags;
+use nix::poll::PollFlags;
 use std::io::Read;
 use std::io::Result;
 use std::io::Seek;
@@ -40,7 +40,7 @@ where
     H: Read + AsRawFd,
 {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        utils::wait_until_ready(self.timeout, &self.handle, EventFlags::POLLIN)?;
+        utils::wait_until_ready(self.timeout, &self.handle, PollFlags::POLLIN)?;
         self.handle.read(buf)
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,7 +29,7 @@ pub fn duration_to_ms(duration: Duration) -> c_int {
 pub fn wait_until_ready<R: AsRawFd>(
     timeout: Option<c_int>,
     to_fd: &R,
-    events: poll::EventFlags,
+    events: poll::PollFlags,
 ) -> Result<()> {
     if let Some(timeout) = timeout {
         let mut pfd = poll::PollFd::new(to_fd.as_raw_fd(), events);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use nix::libc::c_int;
-use nix::poll::EventFlags;
+use nix::poll::PollFlags;
 use std::io::Result;
 use std::io::Seek;
 use std::io::SeekFrom;
@@ -40,12 +40,12 @@ where
     H: Write + AsRawFd,
 {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        utils::wait_until_ready(self.timeout, &self.handle, EventFlags::POLLOUT)?;
+        utils::wait_until_ready(self.timeout, &self.handle, PollFlags::POLLOUT)?;
         self.handle.write(buf)
     }
 
     fn flush(&mut self) -> Result<()> {
-        utils::wait_until_ready(self.timeout, &self.handle, EventFlags::POLLOUT)?;
+        utils::wait_until_ready(self.timeout, &self.handle, PollFlags::POLLOUT)?;
         self.handle.flush()
     }
 }


### PR DESCRIPTION
As an aside, I noticed that the test suite also doesn't pass if you have overwritten `CARGO_TARGET_DIR`, because the computed `CRATE_ROOT` is no longer valid :/