### PR TITLE
update nix to sidestep RUSTSEC-2021-0119

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.3.2-alpha.0"
 repository = "jcreekmore/timeout-readwrite-rs"
 
 [dependencies]
-nix = "0.17.0"
+nix = "0.23.0"
 
 [dev-dependencies]
 lazy_static = "1.3.0"


### PR DESCRIPTION
Hi! ChromeOS uses this repo, and I'm trying to rid our codebase of packages with known RustSec advisories. Please take a look and let me know if you have concerns/questions. :)

Thank you!