### PR TITLE
Update nix and set features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.3.3-alpha.0"
 repository = "jcreekmore/timeout-readwrite-rs"
 
 [dependencies]
-nix = "0.23.0"
+nix = { version = "0.26.0", default-features = false, features = ["poll"] }
 
 [dev-dependencies]
 lazy_static = "1.3.0"


### PR DESCRIPTION
The latest version of `nix` has features to slim down the amount of code being built; `timeout-readwrite-rs` only uses the `"poll"` feature as far as I can tell.